### PR TITLE
TBX-Min Compatibility, Command Line Entry Changes

### DIFF
--- a/TBX2017Converter.pl
+++ b/TBX2017Converter.pl
@@ -99,9 +99,7 @@ sub mode2
 # Function for the rest of the program
 sub program_bulk
 {
-my $dialectcheck = 0;
 my $printfile;
-my $fh = @_;
 
 # Meat of the code: Finding and chaning tags for new standard
 


### PR DESCRIPTION
App is now able to accept TBX-Min files (be them in the current standard or, in rare instances, the older standard) and return them in the same file type. The converter takes advantage of TBX-Min's <TBX> tag that is uppercase (where as TBX-Basic is lowercase to) easily recognize the file type and change "dialect" to type. TBX-Min will likely undergo changes following the TBX revision, and hopefully this will anticipate those changes.

The Command Line order has been changed in order to accommodate the possibility of a second command line option to specify .tbxm and run silently. 
The new order is: perl <perlscript> <filename> <option1> <option2>

The second option, after -s, is -tbxm. If the user wishes to run the program with prompts, then the user will be prompted for file type.
